### PR TITLE
Add custom 404 Not Found page with navigation link

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,24 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-gray-900 to-black text-white">
+      <div className="text-center">
+        <h1 className="text-9xl font-extrabold tracking-widest text-red-500">
+          404
+        </h1>
+        <div className="bg-red-500 px-3 py-1 text-sm rounded rotate-12 absolute">
+          Page Not Found
+        </div>
+        <p className="mt-6 text-lg text-gray-300">
+          Oops! The page you&apos;re looking for doesn&apos;t exist.
+        </p>
+        <Link href="/">
+          <button className="mt-8 px-6 py-3 text-sm font-semibold bg-red-600 rounded-lg hover:bg-red-700 transition">
+            Return Home
+          </button>
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
This pull request introduces a new custom 404 Not Found page to enhance the user experience when encountering non-existent pages. The changes include the creation of a visually appealing and informative error page with a link to navigate back to the homepage.

Closes #15 

Key changes:

* [`app/not-found.tsx`](diffhunk://#diff-fe77a89a1d202b09d5414068d5bb054cb4c597e8f5bd1e72f3e05adcaa9b09a4R1-R24): Created a custom 404 Not Found page with a styled error message, an informative text, and a button that redirects users to the homepage.


### ScreenShot
![image](https://github.com/user-attachments/assets/1c65c6ac-1ce1-4810-8868-861dc8dce98a)
